### PR TITLE
Non measure kinds are not measures.

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4658,7 +4658,8 @@ and TcTupleType kindOpt cenv newOk checkConstraints occ env tpenv isStruct (args
         let isMeasure =
             match kindOpt with
             | Some TyparKind.Measure -> true
-            | None | Some _ -> args |> List.exists(function | TupleTypeSegment.Slash _ -> true | _ -> false)
+            | None -> args |> List.exists(function | TupleTypeSegment.Slash _ -> true | _ -> false)
+            | Some _ -> false
     
         if isMeasure then
             let ms,tpenv = TcMeasuresAsTuple cenv newOk checkConstraints occ env tpenv args m


### PR DESCRIPTION
I found the problem.
We changed a bit too much here.
If the `kindOpt` is `Some`, we don't want to check for a slash, it just never is a measure.

I was able to verify this on my local Windows machine. Before this change, I had that one failing test.
Afterwards, all were green.