### PR TITLE
Use mMethExpr range when returnType is MustConvertTo and LanguageFeature.AdditionalTypeDirectedConversions is enabled.

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -9677,7 +9677,12 @@ and TcMethodApplication
             CanonicalizePartialInferenceProblem cenv.css denv mItem
                  (unnamedCurriedCallerArgs |> List.collectSquared (fun callerArg -> freeInTypeLeftToRight g false callerArg.CallerArgumentType))
 
-        let result, errors = ResolveOverloadingForCall denv cenv.css mItem methodName callerArgs ad postArgumentTypeCheckingCalledMethGroup true returnTy
+        let m =
+            match returnTy with
+            | MustConvertTo _ when g.langVersion.SupportsFeature LanguageFeature.AdditionalTypeDirectedConversions -> mMethExpr
+            | _ -> mItem
+
+        let result, errors = ResolveOverloadingForCall denv cenv.css m methodName callerArgs ad postArgumentTypeCheckingCalledMethGroup true returnTy
 
         match afterResolution, result with
         | AfterResolution.DoNothing, _ -> ()


### PR DESCRIPTION
This works around the problem we found.