### PR TITLE
Add code fix for adding missing `seq` before `{…}`

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingSeq.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingSeq.fs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System.Collections.Immutable
+open System.Composition
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+open Microsoft.CodeAnalysis.CodeFixes
+open Microsoft.CodeAnalysis.Text
+open CancellableTasks
+
+[<Sealed>]
+[<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.ChangeToUpcast); Shared>]
+type internal AddMissingSeqCodeFixProvider() =
+    inherit CodeFixProvider()
+
+    static let title = SR.AddMissingSeq()
+    static let fixableDiagnosticIds = ImmutableArray.Create("FS3873", "FS0740")
+
+    override _.FixableDiagnosticIds = fixableDiagnosticIds
+
+    override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
+
+    override this.GetFixAllProvider() = this.RegisterFsharpFixAll()
+
+    interface IFSharpCodeFixProvider with
+        member _.GetCodeFixIfAppliesAsync context =
+            cancellableTask {
+                let! sourceText = context.GetSourceTextAsync()
+                let! parseFileResults = context.Document.GetFSharpParseResultsAsync(nameof AddMissingSeqCodeFixProvider)
+
+                let getSourceLineStr line =
+                    sourceText.Lines[Line.toZ line].ToString()
+
+                let range =
+                    RoslynHelpers.TextSpanToFSharpRange(context.Document.FilePath, context.Span, sourceText)
+
+                let needsParens =
+                    (range.Start, parseFileResults.ParseTree)
+                    ||> ParsedInput.exists (fun path node ->
+                        match path, node with
+                        | SyntaxNode.SynExpr outer :: _, SyntaxNode.SynExpr(expr & SynExpr.ComputationExpr _) when
+                            expr.Range |> Range.equals range
+                            ->
+                            let seqRange =
+                                range
+                                |> Range.withEnd (Position.mkPos range.Start.Line (range.Start.Column + 3))
+
+                            let inner =
+                                SynExpr.App(
+                                    ExprAtomicFlag.NonAtomic,
+                                    false,
+                                    SynExpr.Ident(Ident(nameof seq, seqRange)),
+                                    expr,
+                                    Range.unionRanges seqRange expr.Range
+                                )
+
+                            let outer =
+                                match outer with
+                                | SynExpr.App(flag, isInfix, funcExpr, _, outerAppRange) ->
+                                    SynExpr.App(flag, isInfix, funcExpr, inner, outerAppRange)
+                                | outer -> outer
+
+                            inner
+                            |> SynExpr.shouldBeParenthesizedInContext getSourceLineStr (SyntaxNode.SynExpr outer :: path)
+                        | _ -> false)
+
+                let text = sourceText.ToString(TextSpan(context.Span.Start, context.Span.Length))
+                let newText = if needsParens then $"(seq {text})" else $"seq {text}"
+
+                return
+                    ValueSome
+                        {
+                            Name = CodeFix.AddMissingSeq
+                            Message = title
+                            Changes = [ TextChange(context.Span, newText) ]
+                        }
+            }

--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingSeq.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingSeq.fs
@@ -19,9 +19,7 @@ type internal AddMissingSeqCodeFixProvider() =
     static let fixableDiagnosticIds = ImmutableArray.Create("FS3873", "FS0740")
 
     override _.FixableDiagnosticIds = fixableDiagnosticIds
-
     override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
-
     override this.GetFixAllProvider() = this.RegisterFsharpFixAll()
 
     interface IFSharpCodeFixProvider with

--- a/vsintegration/src/FSharp.Editor/Common/Constants.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Constants.fs
@@ -208,3 +208,6 @@ module internal CodeFix =
 
     [<Literal>]
     let RemoveUnnecessaryParentheses = "RemoveUnnecessaryParentheses"
+
+    [<Literal>]
+    let AddMissingSeq = "AddMissingSeq"

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -141,6 +141,7 @@
     <Compile Include="CodeFixes\RenameParamToMatchSignature.fs" />
     <Compile Include="CodeFixes\UseTripleQuotedInterpolation.fs" />
     <Compile Include="CodeFixes\RemoveUnnecessaryParentheses.fs" />
+    <Compile Include="CodeFixes\AddMissingSeq.fs" />
     <Compile Include="Build\SetGlobalPropertiesForSdkProjects.fs" />
     <Compile Include="AutomaticCompletion\BraceCompletionSessionProvider.fsi" />
     <Compile Include="AutomaticCompletion\BraceCompletionSessionProvider.fs" />

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
@@ -359,6 +359,9 @@ Use live (unsaved) buffers for analysis</value>
   <data name="RemoveUnnecessaryParentheses" xml:space="preserve">
     <value>Remove unnecessary parentheses</value>
   </data>
+  <data name="AddMissingSeq" xml:space="preserve">
+    <value>Add missing 'seq'</value>
+  </data>
   <data name="RemarksHeader" xml:space="preserve">
     <value>Remarks:</value>
   </data>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Přidat chybějící parametr člena instance</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Přidejte klíčové slovo new.</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Fehlenden Instanzmemberparameter hinzufügen</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Schlüsselwort "new" hinzufügen</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Agregar parámetro de miembro de instancia que falta</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Agregar "nueva" palabra clave</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Ajouter un paramètre de membre d’instance manquant</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Ajouter le mot clé 'new'</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Aggiungi parametro membro di istanza mancante</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Aggiungi la parola chiave 'new'</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">見つからないインスタンス メンバー パラメーターを追加する</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">'new' キーワードを追加する</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">누락된 인스턴스 멤버 매개 변수 추가</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">'new' 키워드 추가</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Dodaj brakujący parametr składowej wystąpienia</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Dodaj słowo kluczowe „new”</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Adicionar parâmetro de membro de instância ausente</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Adicionar a palavra-chave 'new'</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Добавить отсутствующий параметр экземплярного элемента</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Добавить ключевое слово "new"</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Eksik örnek üye parametresini ekleyin</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">'new' anahtar sözcüğünü ekleme</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">添加缺少的实例成员参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">添加“新”关键字</target>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">新增缺少的執行個體成員參數</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddMissingSeq">
+        <source>Add missing 'seq'</source>
+        <target state="new">Add missing 'seq'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">新增 'new' 關鍵字</target>

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingSeqTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingSeqTests.fs
@@ -42,7 +42,7 @@ let ``FS0740 — Adds missing seq before { x; y }`` () =
     Assert.Equal(expected, actual)
 
 [<Fact>]
-let ``FS3873 — Adds parens when needed`` () =
+let ``FS3873 — Adds parens when needed — app`` () =
     let code = "let xs = id { 1..10 }"
 
     let expected =
@@ -57,7 +57,22 @@ let ``FS3873 — Adds parens when needed`` () =
     Assert.Equal(expected, actual)
 
 [<Fact>]
-let ``FS0740 — Adds parens when needed`` () =
+let ``FS3873 — Adds parens when needed — dot`` () =
+    let code = "let s = { 1..10 }.ToString ()"
+
+    let expected =
+        Some
+            {
+                Message = "Add missing 'seq'"
+                FixedCode = "let s = (seq { 1..10 }).ToString ()"
+            }
+
+    let actual = codeFix |> tryFix code mode
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``FS0740 — Adds parens when needed — app`` () =
     let code = "let xs = id { 1; 10 }"
 
     let expected =
@@ -65,6 +80,21 @@ let ``FS0740 — Adds parens when needed`` () =
             {
                 Message = "Add missing 'seq'"
                 FixedCode = "let xs = id (seq { 1; 10 })"
+            }
+
+    let actual = codeFix |> tryFix code mode
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``FS0740 — Adds parens when needed — dot`` () =
+    let code = "let s = { 1; 10 }.ToString ()"
+
+    let expected =
+        Some
+            {
+                Message = "Add missing 'seq'"
+                FixedCode = "let s = (seq { 1; 10 }).ToString ()"
             }
 
     let actual = codeFix |> tryFix code mode

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingSeqTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingSeqTests.fs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.AddMissingSeqTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+open CodeFixTestFramework
+
+let private codeFix = AddMissingSeqCodeFixProvider()
+
+// This can be changed to Auto when featureDeprecatePlacesWhereSeqCanBeOmitted is out of preview.
+let mode = WithOption "--langversion:preview"
+
+[<Fact>]
+let ``FS3873 — Adds missing seq before { start..finish }`` () =
+    let code = "let xs = { 1..10 }"
+
+    let expected =
+        Some
+            {
+                Message = "Add missing 'seq'"
+                FixedCode = "let xs = seq { 1..10 }"
+            }
+
+    let actual = codeFix |> tryFix code mode
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``FS0740 — Adds missing seq before { x; y }`` () =
+    let code = "let xs = { 1; 10 }"
+
+    let expected =
+        Some
+            {
+                Message = "Add missing 'seq'"
+                FixedCode = "let xs = seq { 1; 10 }"
+            }
+
+    let actual = codeFix |> tryFix code mode
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``FS3873 — Adds parens when needed`` () =
+    let code = "let xs = id { 1..10 }"
+
+    let expected =
+        Some
+            {
+                Message = "Add missing 'seq'"
+                FixedCode = "let xs = id (seq { 1..10 })"
+            }
+
+    let actual = codeFix |> tryFix code mode
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``FS0740 — Adds parens when needed`` () =
+    let code = "let xs = id { 1; 10 }"
+
+    let expected =
+        Some
+            {
+                Message = "Add missing 'seq'"
+                FixedCode = "let xs = id (seq { 1; 10 })"
+            }
+
+    let actual = codeFix |> tryFix code mode
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``FS3873 — Adds parens when needed — multiline`` () =
+    let code =
+        """
+let xs =
+    id {
+        1..10
+    }
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Add missing 'seq'"
+                FixedCode =
+                    """
+let xs =
+    id (seq {
+        1..10
+    })
+"""
+            }
+
+    let actual = codeFix |> tryFix code mode
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``FS0740 — Adds parens when needed — multiline`` () =
+    let code =
+        """
+let xs =
+    id {
+        1; 10
+    }
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Add missing 'seq'"
+                FixedCode =
+                    """
+let xs =
+    id (seq {
+        1; 10
+    })
+"""
+            }
+
+    let actual = codeFix |> tryFix code mode
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -72,6 +72,7 @@
     <Compile Include="CodeFixes\ConvertCSharpUsingToFSharpOpenTests.fs" />
     <Compile Include="CodeFixes\ReplaceWithSuggestionTests.fs" />
     <Compile Include="CodeFixes\RemoveUnnecessaryParenthesesTests.fs" />
+    <Compile Include="CodeFixes\AddMissingSeqTests.fs" />
     <Compile Include="Refactors\RefactorTestFramework.fs" />
     <Compile Include="Refactors\AddReturnTypeTests.fs" />
     <Compile Include="Hints\HintTestFramework.fs" />


### PR DESCRIPTION
## Description

- Add code fix for adding missing `seq` before `{…}`.

## Checklist

- [x] Test cases added.
- [ ] Release notes entry updated.